### PR TITLE
Fix RenderEngine::setupLightShaderParam()

### DIFF
--- a/src/RenderEngine.cpp
+++ b/src/RenderEngine.cpp
@@ -261,7 +261,7 @@ void RenderEngine::renderLighting( RenderParam& param , Light* light )
 	glActiveTexture(GL_TEXTURE0);
 }
 
-void RenderEngine::setupLightShaderParam( Shader* shader , Light& light )
+void RenderEngine::setupLightShaderParam( Shader* shader , Light* light )
 {
 	shader->setParam( "colorLight" , light->color );
 	shader->setParam( "dir" , light->dir );

--- a/src/RenderEngine.h
+++ b/src/RenderEngine.h
@@ -63,7 +63,7 @@ private:
 
 	void   renderLighting( RenderParam& param , Light* light );
 	bool   setupFBO( int width , int height );
-	void   setupLightShaderParam( Shader* shader , Light& light );
+	void   setupLightShaderParam( Shader* shader , Light* light );
 
 	std::vector<Shader*> mShaders;
 


### PR DESCRIPTION
**RenderEngine::setupLightShaderParam()** takes a **Light&** as an argument which is, however, treated as if it were **Light***. This is incorrect and causes a compile-time failure.
